### PR TITLE
Increase buffer size by 10x

### DIFF
--- a/WMFMediaInspector/WMFMediaInspector.cpp
+++ b/WMFMediaInspector/WMFMediaInspector.cpp
@@ -237,7 +237,7 @@ void DBGMSG(PCWSTR format, ...)
     va_list args;
     va_start(args, format);
 
-    WCHAR msg[MAX_PATH];
+    WCHAR msg[10*MAX_PATH];
 
     if (SUCCEEDED(StringCbVPrintf(msg, sizeof(msg), format, args)))
     {


### PR DESCRIPTION
Fixes issue of MF_MT_MPEG4_SAMPLE_DESCRIPTION content not being shown due to buffer overflow.